### PR TITLE
review major refactoring of cronjobs

### DIFF
--- a/import-logfiles.sh
+++ b/import-logfiles.sh
@@ -11,7 +11,7 @@ STATS_LOG=$REGAL_LOGS/stats.log
 
 function loadLogFile() {
     PATTERN=$1
-    zgrep --no-filename $PATTERN var/log/apache2/other_vhosts_access.*|sort|uniq > $TMP/matomoImport.log
+    zgrep --no-filename $PATTERN $APACHE_LOG/$APACHE_ACCESS_LOGNAME.*|sort|uniq > $TMP/matomoImport.log
     python $MATOMO/misc/log-analytics/import_logs.py --recorder-max-payload-size=200 --url $MATOMO_URL --login $MATOMO_ADMIN --password $MATOMO_PASSWORD $TMP/matomoImport.log --idsite=$IDSITE >> $STATS_LOG
 }
 

--- a/register_urn.sh
+++ b/register_urn.sh
@@ -46,7 +46,7 @@ fi
 home_dir=$CRONJOBS_DIR
 server=$SERVER
 passwd=$REGAL_PASSWORD
-project=$INDEXNAME
+project=$NAMESPACE
 regalApi=$BACKEND
 urn_api=$OAI_PMH
 oai_id="oai:api.$server:"
@@ -186,7 +186,7 @@ do
     
     # >>> Test für eine einzelne ID
     # if [ "$modus" = "register" ]; then
-    #   addURN=`curl -XPOST -u$ADMIN_USER:$passwd "https://$regalApi/utils/addUrn?id=${id:7}&namespace=$NAMESPACE&snid=hbz:929:02"`
+    #   addURN=`curl -XPOST -u$ADMIN_USER:$passwd "$PROTOCOL://$regalApi/utils/addUrn?id=${id:7}&namespace=$NAMESPACE&snid=hbz:929:02"`
     #   echo "$addURN\n"; # Ausgabe in log-Datei
     #   addURNresponse=${addURN:0:80}
     #   echo -e "$url\t$cdate\t$cat\t$dnb\t$contentType\t\t$addURNresponse" >> $outdatei
@@ -196,7 +196,7 @@ do
 
     if [ "$modus" = "register" ] && [ "$dnb" != "J" ]; then
       # Nachregistrierung des Objektes für URN-Vergabe
-      addURN=`curl -XPOST -u$ADMIN_USER:$passwd "https://$regalApi/utils/addUrn?id=${id:7}&namespace=$NAMESPACE&snid=hbz:929:02"`
+      addURN=`curl -XPOST -u$REGAL_ADMIN:$passwd "$PROTOCOL://$regalApi/utils/addUrn?id=${id:7}&namespace=$NAMESPACE&snid=hbz:929:02"`
       echo "$aktdate: $addURN\n"; # Ausgabe in log-Datei
       addURNresponse=${addURN:0:80}
       echo -e "$url\t$cdate\t$cat\t$dnb\t$contentType\t\t$addURNresponse" >> $outdatei
@@ -210,7 +210,7 @@ do
       # Ausgabe und Weiterbehandlung nur im Fehlerfalle
       # minimalen Update auf das Objekt machen, z.B. über erneutes Setzen der Zugriffrechte
       # dadurch wird das Objekt dann an der Katalogschnittstelle gemeldet
-      update=`curl -H "Content-Type: application/json" -XPATCH -u$ADMIN_USER:$passwd -d'{"publishScheme":"public"}' "https://$regalApi/resource/$id"`
+      update=`curl -H "Content-Type: application/json" -XPATCH -u$ADMIN_USER:$passwd -d'{"publishScheme":"public"}' "$PROTOCOL://$regalApi/resource/$id"`
       echo "$aktdate: $update\n"; # Ausgabe in log-Datei
       updateResponse=${update:0:80}
       echo -e "$url\t$cdate\t$cat\t$contentType\t\t$updateResponse" >> $outdatei
@@ -252,5 +252,3 @@ if [ -s $outdatei ]; then
   mailx -s "$subject" $recipients < $mailbodydatei
   # rm $mailbodydatei
 fi
-
-cd-

--- a/runGatherer.sh
+++ b/runGatherer.sh
@@ -21,7 +21,7 @@ source variables.conf
 home_dir=$CRONJOBS_DIR
 server=$SERVER
 passwd=$REGAL_PASSWORD
-project=$INDEXNAME
+project=$NAMESPACE
 regalApi=$BACKEND
 
 if [ ! -d $REGAL_LOGS ]; then
@@ -34,7 +34,7 @@ echo "home-Verzeichnis: $home_dir"
 echo "Projekt: $project"
 echo "Server: $server"
 
-runGatherer=`curl -XPOST -u$ADMIN_USER:$passwd "$PROTOCOL://$regalApi/utils/runGatherer"`
+runGatherer=`curl -XPOST -u$REGAL_ADMIN:$passwd "$PROTOCOL://$regalApi/utils/runGatherer"`
 echo "$runGatherer\n"; # Ausgabe in Log-Datei
 
 echo "siehe Log-Datei $REGAL_APP/logs/webgatherer.log"

--- a/variables.conf.tmpl
+++ b/variables.conf.tmpl
@@ -1,6 +1,7 @@
 #
 # Project,Namespace,Indexname
 #
+NAMESPACE=edoweb
 INDEXNAME=regal
 #
 # Layout
@@ -13,7 +14,7 @@ REGAL_TMP=$REGAL_HOME/tmp
 REGAL_BACKUP=$REGAL_HOME/backup
 HERITRIX_DIR=$REGAL_HOME/heritrix-data
 APACHE_LOG=/var/log/apache2
-APACHE_ACCESS_LOGNAME=other_vhosts_access.log
+APACHE_ACCESS_LOGNAME=other_vhosts_access
 CRONJOBS_DIR=$REGAL_HOME/regal-scripts
 TOMCAT_HOME=$REGAL_HOME/fedora/tomcat
 TOMCAT_CONF=$TOMCAT_HOME/conf
@@ -35,6 +36,7 @@ MATOMO_PASSWORD=$REGAL_PASSWORD
 # Web-APIs
 #
 SERVER=localhost
+PROTOCOL=https
 BACKEND=http://api.localhost
 FRONTEND=http://$SERVER
 HERITRIX_URL=https://localhost:8443


### PR DESCRIPTION
* kleine Änderungen: Konfigurationsvariablen benutzen: APACHE_LOG, APACHE_ACCESS_LOGNAME, PROTOCOL -- muss alles nicht unbedingt

* ADMIN_USER => REGAL_ADMIN

* $project: war bei mir "edoweb", ist jetzt "regal". Soll das so ? Hast Du den Endpoint auch geändert ?
     curl -s -XGET $ELASTICSEARCH/$project/journal,monograph,file,webpage/_search
     Braucht man nicht doch eine zusätzliche Konfigurationsvariable NAMESPACE ?
     