### PR TITLE
add script to depersonalize apache logs

### DIFF
--- a/depersonalize-apache-logs.sh
+++ b/depersonalize-apache-logs.sh
@@ -21,7 +21,7 @@ function postProcess(){
 #-----------config end-----------------
 
 # Generate list of files to work on
-filesToAnnonymize=`find $logDir -type f -name $extension -mtime +$days`
+filesToAnnonymize=`find $logDir -type f -name $extension ! -name "*.ano.*" -mtime +$days`
 
 # Test if
 if touch $logDir/.annonymize-apache-logs.sh.test > /dev/null 2>&1

--- a/depersonalize-apache-logs.sh
+++ b/depersonalize-apache-logs.sh
@@ -1,0 +1,59 @@
+#! /bin/bash
+
+#
+# Author: Jan Schnasse
+#
+
+# only work on files older then $days 
+days=7
+# look for files in this directory
+logDir="/var/log/apache2/"
+# with this extension 
+extension="*.gz"
+# depersonalize by replacing the last two bytes of an IP with this string
+anoBytes=".0.0"
+# define how to behave after anonymizing 
+function postProcess(){
+  echo Please remove $1 
+  #rm -f $1
+}
+
+#-----------config end-----------------
+
+
+# Generate list of files to work on
+filesToAnnonymize=`find $logDir -type f -name $extension -mtime +$days`
+
+# Test if
+if touch $logDir/.annonymize-apache-logs.sh.test > /dev/null 2>&1
+then
+	rm $logDir/.annonymize-apache-logs.sh.test
+else
+	echo "You don't have permission to write into $logDir"
+	exit 1;
+fi
+
+#Work through each file
+for file in `echo $filesToAnnonymize`
+do
+	# echo Analyse $file
+	# Hashmap to collect ips
+ 	declare -A anoIps
+	# List all ips from $file
+	ips=`zgrep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $file`
+	for ip in `echo $ips`
+	do
+		#anonymize
+		anoIp=`echo $ip|grep -Eo '^[0-9]{1,3}\.[0-9]{1,3}'`
+		anoIp=${anoIp}${anoBytes}
+                #collect
+		anoIps[$ip]=$anoIp;
+	done
+
+	for key in "${!anoIps[@]}"
+	do
+	    # echo "Going to replace all $key with ${anoIps[$key]} in $file" 
+	    zcat $file| replace $key ${anoIps[$key]} |gzip > ${file%.*}.ano.gz  
+	done
+    	postProcess $file
+done

--- a/depersonalize-apache-logs.sh
+++ b/depersonalize-apache-logs.sh
@@ -14,8 +14,8 @@ extension="*.gz"
 anoBytes=".0.0"
 # define how to behave after anonymizing 
 function postProcess(){
-  echo Please remove $1 
-  #rm -f $1
+  #echo Please remove $1 
+  rm -f $1
 }
 
 #-----------config end-----------------

--- a/depersonalize-apache-logs.sh
+++ b/depersonalize-apache-logs.sh
@@ -14,15 +14,15 @@ extension="*.gz"
 anoBytes=".0.0"
 # define how to behave after anonymizing 
 function postProcess(){
-  echo Please remove $1 
-  #rm -f $1
+  echo remove $1 
+  rm -f $1
 }
 
 #-----------config end-----------------
 
 # Generate list of files to work on
-filesToAnnonymize=`find $logDir -type f -name $extension ! -name "*.ano.*" -mtime +$days`
-
+filesToAnnonymize=`find $logDir -type f -name "$extension" ! -name "*.ano.*" -mtime +$days`
+echo "Try to annonymize $filesToAnnonymize"
 # Test if
 if touch $logDir/.annonymize-apache-logs.sh.test > /dev/null 2>&1
 then
@@ -32,10 +32,12 @@ else
 	exit 1;
 fi
 
+datestamp=`date +"%Y%m%d%H%M%s%S"`
+
 #Work through each file
 for file in `echo $filesToAnnonymize`
 do
         # echo Process $file
-    	zcat $file |sed -E "s/([0-9]{1,3}\.[0-9]{1,3})\.[0-9]{1,3}\.[0-9]{1,3}/\1$anoBytes/"|gzip > ${file%.*}.ano.gz 
+    	zcat $file |sed -E "s/([0-9]{1,3}\.[0-9]{1,3})\.[0-9]{1,3}\.[0-9]{1,3}/\1$anoBytes/"|gzip > ${file%.*}.ano.${datestamp}.gz 
 	postProcess $file
 done

--- a/depersonalize-apache-logs.sh
+++ b/depersonalize-apache-logs.sh
@@ -20,7 +20,6 @@ function postProcess(){
 
 #-----------config end-----------------
 
-
 # Generate list of files to work on
 filesToAnnonymize=`find $logDir -type f -name $extension -mtime +$days`
 
@@ -36,24 +35,7 @@ fi
 #Work through each file
 for file in `echo $filesToAnnonymize`
 do
-	# echo Analyse $file
-	# Hashmap to collect ips
- 	declare -A anoIps
-	# List all ips from $file
-	ips=`zgrep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $file`
-	for ip in `echo $ips`
-	do
-		#anonymize
-		anoIp=`echo $ip|grep -Eo '^[0-9]{1,3}\.[0-9]{1,3}'`
-		anoIp=${anoIp}${anoBytes}
-                #collect
-		anoIps[$ip]=$anoIp;
-	done
-
-	for key in "${!anoIps[@]}"
-	do
-	    # echo "Going to replace all $key with ${anoIps[$key]} in $file" 
-	    zcat $file| replace $key ${anoIps[$key]} |gzip > ${file%.*}.ano.gz  
-	done
-    	postProcess $file
+        # echo Process $file
+    	zcat $file |sed -E "s/([0-9]{1,3}\.[0-9]{1,3})\.[0-9]{1,3}\.[0-9]{1,3}/\1$anoBytes/"|gzip > ${file%.*}.ano.gz 
+	postProcess $file
 done


### PR DESCRIPTION
- the script should list all gz files older then
seven days in /var/log/apache2 and remove the last
two bytes from the IP entry of each logging line
- a copy of the original file will be stored in a file
named with an additional "ano" prefix
- by default the original file is kept. Just uncomment
the `rm -f` line in the postProcess function to automatically
delete files after processing