### PR TITLE
add script to move files from crawldir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,4 @@ conf/application.conf
 scripts/variables.conf
 *~
 variables.conf
-ks.*
 regal-scripts.HIST

--- a/README.md
+++ b/README.md
@@ -1,38 +1,40 @@
-# Installation regal-scripts
-    cd /opt/regal
-    git clone https://github.com/edoweb/regal-scripts.git
-    cd regal-scripts
-
-# Edit variables and adjust to your own settings
-    cp variables.conf.tmpl variables.conf
-    editor variables.conf
-    
-# Create soft links
-    cd /opt/edoweb/bin
-    ln -s /opt/regal/regal-scripts/cdn cdn
-    
-# Define cron jobs
-Sample crontab:
-# For more information see the manual pages of crontab(5) and cron(8)
-# 
-# m h  dom mon dow   command
-0 2 * * * /opt/regal/regal-scripts/turnOnOaiPmhPolling.sh
-0 5 * * * /opt/regal/regal-scripts/turnOffOaiPmhPolling.sh
-05 7 * * * /opt/regal/regal-scripts/register_urn.sh control  >> /opt/regal/cronjobs/log/control_urn_vergabe.log
-1 1 * * * /opt/regal/regal-scripts/register_urn.sh katalog >> /opt/regal/cronjobs/log/katalog_update.log
-1 0 * * * /opt/regal/regal-scripts/register_urn.sh register >> /opt/regal/cronjobs/log/register_urn.log
-0 5 * * * /opt/regal/regal-scripts/updateAll.sh > /dev/null
-#0 23 * * * /opt/regal/regal-scripts/loadCache.sh
-0 1 * * * /opt/regal/regal-scripts/import-logfiles.sh >/dev/null
-# Start Edoweb Webgatherer Sequenz
-0 20 * * * /opt/regal/regal-scripts/runGatherer.sh >> /opt/regal/cronjobs/log/runGatherer.log
-# Auswertung des letzten Webgatherer-Laufs
-0 21 * * * /opt/regal/regal-scripts/evalWebgatherer.sh >> /opt/regal/cronjobs/log/runGatherer.log
-# Indexierung neu geharvesteter Webschnitte
-0 2 * * * /opt/regal/regal-scripts/backup-es.sh -c >> /opt/regal/cronjobs/log/backup-es.log 2>&1
-30 2 * * * /opt/regal/regal-scripts/backup-es.sh -b >> /opt/regal/cronjobs/log/backup-es.log 2>&1
-0 2 * * * /opt/regal/regal-scripts/backup-db.sh -c >> /opt/regal/cronjobs/log/backup-db.log 2>&1
-30 2 * * * /opt/regal/regal-scripts/backup-db.sh -b >> /opt/regal/cronjobs/log/backup-db.log 2>&1
-0 2 * * * /opt/regal/regal-scripts/depersonalize-apache-logs.sh
-# Crawl Reports
-0 22 * * * /opt/regal/regal-scripts/crawlReport.sh >> /opt/regal/cronjobs/log/crawlReport.log
+# Installation regal-scripts  
+    cd /opt/regal  
+    git clone https://github.com/edoweb/regal-scripts.git  
+    cd regal-scripts  
+  
+# Edit variables and adjust to your own settings  
+    cp variables.conf.tmpl variables.conf  
+    editor variables.conf  
+      
+# Create soft links  
+    cd /opt/edoweb/bin  
+    ln -s /opt/regal/regal-scripts/cdn cdn  
+      
+# Define cron jobs  
+Sample crontab:  
+    # For more information see the manual pages of crontab(5) and cron(8)  
+    #   
+    # m h  dom mon dow   command  
+    0 2 * * * /opt/regal/regal-scripts/turnOnOaiPmhPolling.sh  
+    0 5 * * * /opt/regal/regal-scripts/turnOffOaiPmhPolling.sh  
+    05 7 * * * /opt/regal/regal-scripts/register_urn.sh control  >> /opt/regal/cronjobs/log/control_urn_vergabe.log  
+    1 1 * * * /opt/regal/regal-scripts/register_urn.sh katalog >> /opt/regal/cronjobs/log/katalog_update.log  
+    1 0 * * * /opt/regal/regal-scripts/register_urn.sh register >> /opt/regal/cronjobs/log/register_urn.log  
+    0 5 * * * /opt/regal/regal-scripts/updateAll.sh > /dev/null  
+    #0 23 * * * /opt/regal/regal-scripts/loadCache.sh  
+    0 1 * * * /opt/regal/regal-scripts/import-logfiles.sh >/dev/null  
+    # Start Edoweb Webgatherer Sequenz  
+    0 20 * * * /opt/regal/regal-scripts/runGatherer.sh >> /opt/regal/cronjobs/log/runGatherer.log  
+    # Auswertung des letzten Webgatherer-Laufs  
+    0 21 * * * /opt/regal/regal-scripts/evalWebgatherer.sh >> /opt/regal/cronjobs/log/runGatherer.log  
+    # Verschieben von Dateien aus dem Arbeitsverzeichnis von wpull ins Outputverzeichnis von wpull  
+    0 22 * * * /opt/regal/regal-scripts/ks.move_files_from_crawldir.sh >> /opt/regal/cronjobs/log/ks.move_files_from_crawldir.log  
+    # Indexierung neu geharvesteter Webschnitte  
+    0 2 * * * /opt/regal/regal-scripts/backup-es.sh -c >> /opt/regal/cronjobs/log/backup-es.log 2>&1  
+    30 2 * * * /opt/regal/regal-scripts/backup-es.sh -b >> /opt/regal/cronjobs/log/backup-es.log 2>&1  
+    0 2 * * * /opt/regal/regal-scripts/backup-db.sh -c >> /opt/regal/cronjobs/log/backup-db.log 2>&1  
+    30 2 * * * /opt/regal/regal-scripts/backup-db.sh -b >> /opt/regal/cronjobs/log/backup-db.log 2>&1  
+    0 2 * * * /opt/regal/regal-scripts/depersonalize-apache-logs.sh  
+    # Crawl Reports  
+    0 22 * * * /opt/regal/regal-scripts/crawlReport.sh >> /opt/regal/cronjobs/log/crawlReport.log  

--- a/ks.move_files_from_crawldir.sh
+++ b/ks.move_files_from_crawldir.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Dieses Skript verschiebt Dateien aus dem wpull-Arbeitsverzeichnis in das wpull-Outputverzeichnis.
+# Das Verschieben wird nur durchgeführt, wenn im Arbeitsverzeichnis keine WARC-Datei mehr liegt.
+# Dass im Arbeitsverzeichnis keine WARC-Datei mehr liegt bedeutet, dass der Crawl beendet ist.
+# Grundsätzlich werden alle Dateien aus dem Arbeitsverzeichnis verschoben. Das Arbeitsverzeichnis wird anschließend gelöscht.
+# Typische Dateien, die von der Verschiebung betroffen sind, sind Log-Dateien (cdncrawl.log, cdnparse.log, cdn.txt, crawl.log) und die DB-Dateien (*.db).
+# Autor : I. Kuss
+# Datum : 05.03.2020
+echo "*************************************************************"
+echo "BEGINN move files from crawldir " `date`
+echo "*************************************************************"
+jobDir=/opt/regal/wpull-data-crawldir
+outDir=/opt/regal/wpull-data
+cd $jobDir
+for crawldir in `ls -d edoweb:*/20*/`; do
+  echo "crawldir=$crawldir"
+  cd $jobDir/$crawldir
+  for warcfile in *.warc.gz; do
+    if [ -e "$warcfile" ]; then
+      # WARC-Datei existiert, nichts verschieben
+      echo "Crawl läuft noch oder ist abgebrochen."
+      break
+    fi
+    # Dateien verschieben
+    echo "Crawl wurde abgeschlossen. Dateien werden verschoben."
+    mv * $outDir/$crawldir
+    aktdirname=`basename $PWD`
+    cd ..
+    rmdir $aktdirname
+    echo "Verzeichnis $PWD/$aktdirname wurde gelöscht."
+    if [ -z "$(ls -A $PWD)" ]; then
+      # aktuelles Verzeichnis ist leer
+      aktdirname=`basename $PWD`
+      cd ..
+      rmdir $aktdirname
+      echo "Verzeichnis $PWD/$aktdirname wurde gelöscht."
+    fi
+  done
+done
+echo "ENDE move files from crawldir " `date`
+echo
+exit 0


### PR DESCRIPTION
  - Dieses Skript verschiebt Dateien aus dem Arbeitsverzeichnis von wpull in das Outputverzeichnis von wpull.
  - Das Verschieben findet nur statt, wenn im Arbeitsverzeichnis keine WARC-Datei mehr liegt. Also, wenn der Crawl abgeschlossen ist.
  - Verschoben wird alles in dem Arbeitsverzeichnis, das Arbeitsverzeichnis wird anschließend gelöscht.
-   Dieses Skript sollte als cronjob eingestellt werden; auf edoweb-dev habe ich das mal gemacht.