### PR TITLE
Nachregistrierung der Objekte seit 19.12.2019

### DIFF
--- a/crawlReport.sh
+++ b/crawlReport.sh
@@ -382,8 +382,9 @@ echo "Aktuelle Speicherplatzbelegung (Summen) durch Website-Crawls: $baseUrl/`ba
 echo "Aktuelle Status und Kennzahlen der einzelnen Crawl-Aufträge : $baseUrl/`basename $crawlReport`" >> $mailbodydatei
 
 subject="edoweb Website Crawl Reports"
+xheader="X-Edoweb: $(hostname) crawl reports"
 recipients=$EMAIL_RECIPIENT_PROJECT_ADMIN
-mailx -s "$subject" $recipients < $mailbodydatei
+mailx -s "$subject" -a "$xheader" $recipients < $mailbodydatei
 # rm $mailbodydatei
 
 exit 0

--- a/ks.move_files_from_crawldir.sh
+++ b/ks.move_files_from_crawldir.sh
@@ -26,6 +26,7 @@ for crawldir in `ls -d edoweb:*/20*/`; do
   for warcfile in *.warc.gz; do
     if [ -e "$warcfile" ]; then
       # WARC-Datei existiert, nichts verschieben
+      echo "WARC-Datei $warcfile existiert."
       echo "Crawl läuft noch oder ist abgebrochen."
       break
     fi


### PR DESCRIPTION
  - Es werden alle Objekte, die zwischen 19.12.2019 und 01.07.2020 angelegt wurden, an der OAI-PMH-Schnittstelle nachregistriert.
  - Ab dem 13.07. läuft das Skript wieder im Normalbetrieb